### PR TITLE
fix: mBrick-R USBCDC及pinmap问题

### DIFF
--- a/mbrick_r/board.json
+++ b/mbrick_r/board.json
@@ -221,8 +221,18 @@
             "Serial"
         ],
         [
+            "Serial0",
+            "Serial0"
+        ],
+        [
             "Serial1",
             "Serial1"
+        ]
+    ],
+    "cdcSerialPort": [
+        [
+            "Serial(USB CDC)",
+            "Serial"
         ]
     ],
     "serialPins": {
@@ -236,14 +246,24 @@
                 "21"
             ]
         ],
-        "Serial1": [
+        "Serial0": [
             [
                 "RX",
-                "18"
+                "20"
             ],
             [
                 "TX",
-                "19"
+                "21"
+            ]
+        ],
+        "Serial1": [
+            [
+                "RX",
+                "10"
+            ],
+            [
+                "TX",
+                "9"
             ]
         ]
     },
@@ -293,7 +313,7 @@
                 "MISO",
                 5
             ],
-            [
+            [ 
                 "SCK",
                 4
             ]
@@ -339,11 +359,11 @@
         "Wire": [
             [
                 "SDA",
-                "7"
+                "10"
             ],
             [
                 "SCL",
-                "8"
+                "9"
             ]
         ]
     },

--- a/mbrick_r/pinmap.json
+++ b/mbrick_r/pinmap.json
@@ -35,7 +35,7 @@
           "disabled": false
         },
         {
-          "name": "D1",
+          "name": "D2",
           "type": "pwm",
           "visible": true,
           "disabled": false
@@ -314,7 +314,7 @@
           "disabled": false
         },
         {
-          "name": "D2",
+          "name": "D1",
           "type": "pwm",
           "visible": true,
           "disabled": false


### PR DESCRIPTION
USBCDC和Serial0引脚冲突造成USB模拟串口Enable失效；
pinmap:D1/D2标注错误。