### PR TITLE
fix(ci13xx): 显示串口默认引脚提示

### DIFF
--- a/ci1302/board.json
+++ b/ci1302/board.json
@@ -41,6 +41,11 @@
     ["Serial1", "Serial1"],
     ["Serial2", "Serial2"]
   ],
+  "serialPins": {
+    "Serial": [["RX", "PB6"], ["TX", "PB5"]],
+    "Serial1": [["RX", "PA3"], ["TX", "PA2"]],
+    "Serial2": [["RX", "PA6"], ["TX", "PA5"]]
+  },
   "serialSpeed": [
     ["1200", "1200"],
     ["9600", "9600"],

--- a/ci1303/board.json
+++ b/ci1303/board.json
@@ -41,6 +41,11 @@
     ["Serial1", "Serial1"],
     ["Serial2", "Serial2"]
   ],
+  "serialPins": {
+    "Serial": [["RX", "PB6"], ["TX", "PB5"]],
+    "Serial1": [["RX", "PA3"], ["TX", "PA2"]],
+    "Serial2": [["RX", "PA6"], ["TX", "PA5"]]
+  },
   "serialSpeed": [
     ["1200", "1200"],
     ["9600", "9600"],

--- a/ci1306/board.json
+++ b/ci1306/board.json
@@ -71,6 +71,11 @@
     ["Serial1", "Serial1"],
     ["Serial2", "Serial2"]
   ],
+  "serialPins": {
+    "Serial": [["RX", "PB6"], ["TX", "PB5"]],
+    "Serial1": [["RX", "PC0"], ["TX", "PB7"]],
+    "Serial2": [["RX", "PB2"], ["TX", "PB1"]]
+  },
   "serialSpeed": [
     ["1200", "1200"],
     ["9600", "9600"],


### PR DESCRIPTION
## 分流与问题

Closes #115

该 Issue 由 `ailyProject/aily-blockly#555` 原生转移而来。问题属于开发板配置 Bug：`@aily-project/lib-core-serial` 已支持读取 `board.json.serialPins` 并在串口下拉项中显示默认 RX/TX，但 CI1302、CI1303、CI1306 的板卡配置没有声明该字段。

## 修改

- CI1302 / CI1303
  - Serial：RX PB6 / TX PB5
  - Serial1：RX PA3 / TX PA2
  - Serial2：RX PA6 / TX PA5
- CI1306
  - Serial：RX PB6 / TX PB5
  - Serial1：RX PC0 / TX PB7
  - Serial2：RX PB2 / TX PB1

映射依据为本机安装的 ChipIntelli CI13XX Arduino Core 1.0.8 中各 variant 的 `pins_arduino.h`。这是配置层修正，不修改 SDK；开发板包及 SDK 版本继续保持 `1.0.8` 一致。

## 验证

环境：

- Arduino CLI 1.5.1：`C:\Program Files\Arduino CLI\arduino-cli.exe`
- Core：`chipintelli:ci13xx@1.0.8`

通过：

- `node .scripts/validate-boards-compliance.js ci1302`
- `node .scripts/validate-boards-compliance.js ci1303`
- `node .scripts/validate-boards-compliance.js ci1306`
- `node .scripts/test-boards-compliance.js`
- JSON 映射断言与 `git diff --check`
- 临时项目本地安装三个开发板包，确认模板和 `board.json` 可加载，并生成预期串口标签
- 对以下 FQBN 分别使用 `--clean` 编译 Blink 与三路 Serial 示例：
  - `chipintelli:ci13xx:ci1302`
  - `chipintelli:ci13xx:ci1303`
  - `chipintelli:ci13xx:ci1306`

## 兼容性与风险

改动只增加运行时板卡元数据，不改变编译、上传、模板或依赖。CI1302/CI1303 的 Serial1 与 Wire 共用 PA2/PA3，CI1306 的 Serial1 与 Wire 共用 PB7/PC0；本 PR 仅展示真实映射，不改变 Core 的资源互斥行为。

本机仅检测到无法识别型号的 COM4/COM8，因此没有自动上传，也未进行目标板硬件串口冒烟测试。
